### PR TITLE
Feat/input capture impl

### DIFF
--- a/src/portals/InputCapture.cpp
+++ b/src/portals/InputCapture.cpp
@@ -320,7 +320,7 @@ dbUasv CInputCapturePortal::onGetZones(sdbus::ObjectPath requestHandle, sdbus::O
 
     std::unordered_map<std::string, sdbus::Variant> results;
     results["zones"]    = sdbus::Variant{zones};
-    results["zone_set"] = sdbus::Variant{++lastZoneSet};
+    results["zone_set"] = sdbus::Variant{lastZoneSet};
     Debug::log(LOG, "[input-capture]  | zoneSet: {}", lastZoneSet);
     return {0, results};
 }

--- a/src/portals/InputCapture.cpp
+++ b/src/portals/InputCapture.cpp
@@ -339,13 +339,25 @@ dbUasv CInputCapturePortal::onSetPointerBarriers(sdbus::ObjectPath requestHandle
 
     Debug::log(LOG, "[input-capture]  | zoneSet: {}", zoneSet);
 
+    std::vector<uint> failedBarriers;
     if (zoneSet != lastZoneSet) {
-        Debug::log(WARN, "[input-capture] Invalid zone set, discarding barriers");
-        return {0, {}}; //TODO: We should return failed_barries
+        for (const auto& b : barriers) {
+            if (!b.contains("barrier_id"))
+                continue;
+
+            try {
+                failedBarriers.push_back(b.at("barrier_id").get<uint>());
+            } catch (std::exception& e) { Debug::log(WARN, "[input-capture] invalid barrier_id in stale zone set request: {}", e.what()); }
+        }
+
+        Debug::log(WARN, "[input-capture] Invalid zone set {}, current {}, discarding {} barriers", zoneSet, lastZoneSet, failedBarriers.size());
+
+        std::unordered_map<std::string, sdbus::Variant> results;
+        results["failed_barriers"] = sdbus::Variant{failedBarriers};
+        return {0, results};
     }
 
     auto& session = sessions[sessionHandle];
-    std::vector<uint> failedBarriers;
     session->barrierIdMap.clear();
     session->whandle->sendClearBarriers();
 

--- a/src/portals/InputCapture.hpp
+++ b/src/portals/InputCapture.hpp
@@ -50,7 +50,7 @@ class CInputCapturePortal {
     //
     std::unique_ptr<sdbus::IObject> m_pObject;
     uint                            sessionCounter = 0;
-    uint                            lastZoneSet    = 0;
+    uint                            lastZoneSet    = 1;
     uint32_t                        barrierIdCounter = 1;
 
     //


### PR DESCRIPTION
I was hunting down the scaling issues and found that sometimes Deskflow was failing when switching layouts because of wrongly reported zone sets which was always increased inside the zones getter. The `lastZoneSet` still gets updated in `zonesChanged()` so the logic should be more solid now.

Also, implemented the "todo" for returning failed barriers when zone sets don't match, which I thought would help initially with my issue, but this can be dropped if needed or if the implementation is not good enough.